### PR TITLE
fix: cart state reducers update and add, to allow same item multiple …

### DIFF
--- a/client/src/components/CartPreview.jsx
+++ b/client/src/components/CartPreview.jsx
@@ -29,19 +29,16 @@ const CartPreview = () => {
   }
 
 
-  const controlProductAmount = (action, id) => {
-    const item = cart.find(item => item.id === id)
-    const newAmount = item.amount === 1 ? dispatch(deleteProductFromCart({ id }))
-      : action === "minus" ? item.amount - 1
-        : Math.min(item.amount + 1, item.isStock)
+  const controlProductAmount = (action, id, condition) => {
+    const item = cart.find(item => item.id === id && item.condition === condition)
+    console.log(item)
+    const newAmount = action === "minus" && item.amount === 1
+      ? dispatch(deleteProductFromCart({ id, condition }))
+      : action === "minus"
+        ? item.amount - 1
+        : Math.min(item.amount + 1, item.inStock)
 
-    dispatch(updateCartItemAmount({ id, amount: newAmount }))
-    /*
-   if (action === "minus") {
-     dispatch(updateCartItemAmount({ id, amount: cart.find(item => item.id === id).amount - 1 }))
-   } else {
-     dispatch(updateCartItemAmount({ id, amount: cart.find(item => item.id === id).amount + 1 }))
-   }*/
+    dispatch(updateCartItemAmount({ id, condition, amount: newAmount }))
   }
 
   return (
@@ -55,17 +52,17 @@ const CartPreview = () => {
               <MdClose onClick={handleClosePreview} />
             </div>
             {cart.map((item) => (
-              <div key={item.id} className="container">
+              <div key={`${item.id}-${item.condition ?? 'no-condition'}`} className="container">
                 <div className="cart-item-container">
                   <img src={placeholderIMG} alt="product image" />
                   <div className="cart-item-info">
                     <p>{item.name}</p>
                     <div className="cart-item-action">
                       <div className="cart-item-amount">
-                        {item.amount === 1 ? <LiaTrashAlt onClick={() => controlProductAmount("minus", item.id)} /> :
-                          <LiaMinusCircleSolid onClick={() => controlProductAmount("minus", item.id)} />}
+                        {item.amount === 1 ? <LiaTrashAlt onClick={() => controlProductAmount("minus", item.id, item.condition)} /> :
+                          <LiaMinusCircleSolid onClick={() => controlProductAmount("minus", item.id, item.condition)} />}
                         <p>{item.amount}</p>
-                        <LiaPlusCircleSolid onClick={() => controlProductAmount("plus", item.id)} />
+                        <LiaPlusCircleSolid onClick={() => controlProductAmount("plus", item.id, item.condition)} />
                       </div>
                       <div className="cart-item-price">
                         <p>{item.discountPrice ? item.discountPrice : item.normalPrice}</p>

--- a/client/src/components/ProductVersionList.jsx
+++ b/client/src/components/ProductVersionList.jsx
@@ -19,7 +19,7 @@ const ProductVersionList = ({ product, handleSetCurrentItem, discount }) => {
       <ul>
         {product.map((item, index) => (
           <li key={item.condition} className="product-item">
-            <input type="radio" name="item_price" onChange={() => handleSetCurrentItem(item.price, item.amount)} defaultChecked={index === 0} />
+            <input type="radio" name="item_price" onChange={() => handleSetCurrentItem(item.price, item.amount, item.condition)} defaultChecked={index === 0} />
             <div className="condition">
               {discount > 0 ?
                 <p><span className="discount-span">{item.price}€</span>{getDiscountedPrice(item.price, discount)}€ <span>(InStock: {item.amount})</span></p>

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -14,6 +14,7 @@ const ProductPage = () => {
   const [currentItemPrice, setCurrentItemPrice] = useState(0);
   const [currentItemStock, setCurrentItemStock] = useState(1)
   const [productAmount, setProductAmount] = useState(1);
+  const [currentItemCondition, setCurrentItemCondition] = useState('')
   const cart = useSelector((state) => state.cart)
 
   const dispatch = useDispatch();
@@ -26,6 +27,7 @@ const ProductPage = () => {
       if (Array.isArray(product.price)) {
         setCurrentItemPrice(product.price[0].price);
         setCurrentItemStock(product.price[0].amount);
+        setCurrentItemCondition(product.price[0].condition)
       } else {
         setCurrentItemPrice(product.price);
         setCurrentItemStock(product.amount);
@@ -49,12 +51,11 @@ const ProductPage = () => {
     }
   }
 
-
-  const handleSetCurrentItem = (price, amount) => {
+  const handleSetCurrentItem = (price, amount, condition) => {
     setCurrentItemPrice(price)
     setCurrentItemStock(amount)
     setProductAmount(1)
-    console.log(currentItemPrice)
+    setCurrentItemCondition(condition)
   }
 
   if (isLoading) {
@@ -70,7 +71,7 @@ const ProductPage = () => {
       id: product.id,
       name: product.productName,
       amount: productAmount,
-      isStock: product.amount,
+      inStock: currentItemStock,
       normalPrice: currentItemPrice,
     }
     if (product.discount > 0) {
@@ -78,13 +79,19 @@ const ProductPage = () => {
       productValues.discountPrice = discount
     }
 
-    const existingItem = cart.find(item => item.id === product.id)
+    if (checkCategories) {
+      productValues.condition = currentItemCondition
+    }
+
+    const existingItem = cart.find(item => item.id === product.id && (!checkCategories || item.condition === currentItemCondition));
     if (existingItem) {
-      dispatch(updateCartItemAmount({ id: existingItem.id, amount: productAmount }))
+      dispatch(updateCartItemAmount({ id: existingItem.id, amount: productAmount, condition: existingItem.condition }))
       return
     }
     dispatch(addItemsToCart(productValues))
   }
+
+  const checkCategories = product?.categories.some(item => item.name === "Single card")
 
   return (
     <section>
@@ -119,7 +126,7 @@ const ProductPage = () => {
                   </span>
                 </button>
               </div>
-              {product.categories.some(category => category.name === "Single card") ?
+              {checkCategories ?
                 <ProductVersionList discount={product.discount} product={product.price} handleSetCurrentItem={handleSetCurrentItem} />
                 : null}
             </div>

--- a/client/src/redux/reducers/cartReducer.js
+++ b/client/src/redux/reducers/cartReducer.js
@@ -11,12 +11,12 @@ const cartSlice = createSlice({
       return state.concat(action.payload)
     },
     updateCartItemAmount: (state, action) => {
-      const { id, amount } = action.payload
-      return state.map(item => item.id === id ? { ...item, amount } : item)
+      const { id, amount, condition } = action.payload
+      return state.map(item => item.id === id && item.condition === condition ? { ...item, amount } : item)
     },
     deleteProductFromCart: (state, action) => {
-      const { id } = action.payload;
-      return state.filter(item => item.id !== id)
+      const { id, condition } = action.payload;
+      return state.filter(item => !(item.id === id && item.condition === condition))
     },
   }
 })


### PR DESCRIPTION
…times in cart, using product condition and id

*problem -> cart would not allow "single card" category items to be added multiple times to the cart

*It is now possible to add same id item that already exist in the cart again.
*reducer updateCartItemAmount and deleteProductFromCart now check for additional "condition" value and will perform the actions to item that matches id and condition values